### PR TITLE
Fix index creation failure and data migration failure caused by too long email field.

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email', 200)->unique();
             $table->string('password')->nullable();
             $table->rememberToken();
             $table->timestamps();


### PR DESCRIPTION
SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000
  bytes (SQL: alter table `users` add unique `users_email_unique`(`email`))
